### PR TITLE
Move sdl2 error-checking to a separate module

### DIFF
--- a/platformer.nim
+++ b/platformer.nim
@@ -141,18 +141,18 @@ proc restartPlayer(player: Player) =
   player.time.begin = -1
   player.time.finish = -1
 
-proc newTime: Time =
+proc newTime: Time not nil =
   new result
   result.finish = -1
   result.best = -1
 
-proc newPlayer(texture: TexturePtr): Player =
+proc newPlayer(texture: TexturePtr): Player not nil =
   new result
   result.texture = texture
   result.time = newTime()
   result.restartPlayer()
 
-proc newMap(texture: TexturePtr, map: Stream): Map =
+proc newMap(texture: TexturePtr, map: Stream): Map not nil =
   new result
   result.texture = texture
   result.tiles = @[]
@@ -179,26 +179,26 @@ proc newMap(texture: TexturePtr, map: Stream): Map =
 const dataDir = "data"
 
 when defined(embedData):
-  template readRW(filename: string): ptr RWops =
+  template readRW(filename: string): ptr RWops not nil =
     const file = staticRead(dataDir / filename)
     safeRwFromConstMem(file.cstring, file.len)
 
-  template readStream(filename: string): Stream =
+  template readStream(filename: string): Stream not nil =
     const file = staticRead(dataDir / filename)
     newStringStream(file)
 else:
   let fullDataDir = getAppDir() / dataDir
 
-  template readRW(filename: string): ptr RWops =
+  template readRW(filename: string): ptr RWops not nil =
     safeRwFromFile(cstring(fullDataDir / filename), "r")
 
-  template readStream(filename: string): Stream =
+  template readStream(filename: string): Stream not nil=
     var stream = newFileStream(fullDataDir / filename)
     if stream.isNil: raise ValueError.newException(
       "Cannot open file stream:" & fullDataDir / filename)
     stream
 
-proc newGame(renderer: RendererPtr): Game =
+proc newGame(renderer: RendererPtr): Game not nil =
   new result
   result.renderer = renderer
 

--- a/platformer.nim
+++ b/platformer.nim
@@ -110,7 +110,7 @@ proc renderText(renderer: RendererPtr, font: FontPtr, text: string,
 
   surface.safeFreeSurface()
 
-proc renderText(game: Game, text: string, x, y: cint, color: Color,
+proc renderText(game: Game not nil, text: string, x, y: cint, color: Color,
                 tc: TextCache) =
   let passes = [(color: color(0, 0, 0, 64), outline: 2.cint),
                 (color: color, outline: 0.cint)]
@@ -130,7 +130,7 @@ proc renderText(game: Game, text: string, x, y: cint, color: Color,
     game.renderer.safeCopyEx(tc.cache[i].texture, source, dest,
                              angle = 0.0, center = nil)
 
-template renderTextCached(game: Game, text: string, x, y: cint, color: Color) =
+template renderTextCached(game: Game not nil, text: string, x, y: cint, color: Color) =
   block:
     var tc {.global.} = newTextCache()
     game.renderText(text, x, y, color, tc)
@@ -220,7 +220,7 @@ proc toInput(key: Scancode): Input =
   of SDL_SCANCODE_Q: Input.quit
   else: Input.none
 
-proc handleInput(game: Game) =
+proc handleInput(game: Game not nil) =
   var event = defaultEvent
   while safePollEvent(event):
     case event.kind
@@ -242,7 +242,7 @@ proc formatTimeExact(ticks: int): string =
   let cents = (ticks mod 50) * 2
   interp"${formatTime(ticks)}:${cents:02}"
 
-proc render(game: Game, tick: int) =
+proc render(game: Game not nil, tick: int) =
   # Draw over all drawings of the last frame with the default color
   game.renderer.safeClear()
   # Actual drawing here
@@ -329,7 +329,7 @@ proc moveBox(map: Map, pos: var Point2d, vel: var Vector2d,
 
     pos = newPos
 
-proc physics(game: Game) =
+proc physics(game: Game not nil) =
   if game.inputs[Input.restart]:
     game.player.restartPlayer()
 
@@ -351,7 +351,7 @@ proc physics(game: Game) =
 
   game.map.moveBox(game.player.pos, game.player.vel, playerSize)
 
-proc moveCamera(game: Game) =
+proc moveCamera(game: Game not nil) =
   const halfWin = float(windowSize.x div 2)
   when defined(fluidCamera):
     let dist = game.camera.x - game.player.pos.x + halfWin
@@ -364,7 +364,7 @@ proc moveCamera(game: Game) =
   else:
     game.camera.x = game.player.pos.x - halfWin
 
-proc logic(game: Game, tick: int) =
+proc logic(game: Game not nil, tick: int) =
   let time = addr game.player.time
   case game.map.getTile(game.player.pos)
   of start:

--- a/platformer.nim
+++ b/platformer.nim
@@ -373,7 +373,7 @@ proc moveCamera(game: Game) =
     game.camera.x = game.player.pos.x - halfWin
 
 proc logic(game: Game, tick: int) =
-  template time: expr = game.player.time
+  let time = addr game.player.time
   case game.map.getTile(game.player.pos)
   of start:
     time.begin = tick

--- a/platformer.nim
+++ b/platformer.nim
@@ -2,9 +2,9 @@ import
   sdl2, sdl2.image, sdl2.ttf,
   basic2d, strutils, times, math, strfmt, os, streams
 
-type
-  SDLException = object of Exception
+import safe_sdl2
 
+type
   Input {.pure.} = enum none, left, right, jump, restart, quit
 
   Collision {.pure.} = enum x, y, corner
@@ -51,10 +51,6 @@ const
   start = 78
   finish = 110
 
-template sdlFailIf(cond: typed, reason: string) =
-  if cond: raise SDLException.newException(
-    reason & ", SDL error: " & $getError())
-
 proc renderTee(renderer: RendererPtr, texture: TexturePtr, pos: Point2d) =
   let
     x = pos.x.cint
@@ -80,8 +76,8 @@ proc renderTee(renderer: RendererPtr, texture: TexturePtr, pos: Point2d) =
   ]
 
   for part in bodyParts.mitems:
-    renderer.copyEx(texture, part.source, part.dest, angle = 0.0,
-                    center = nil, flip = part.flip)
+    renderer.safeCopyEx(texture, part.source, part.dest, angle = 0.0,
+                        center = nil, flip = part.flip)
 
 proc renderMap(renderer: RendererPtr, map: Map, camera: Vector2d) =
   var
@@ -96,25 +92,23 @@ proc renderMap(renderer: RendererPtr, map: Map, camera: Vector2d) =
     dest.x = cint(i mod map.width) * tileSize.x - camera.x.cint
     dest.y = cint(i div map.width) * tileSize.y - camera.y.cint
 
-    renderer.copy(map.texture, unsafeAddr clip, unsafeAddr dest)
+    renderer.safeCopy(map.texture, unsafeAddr clip, unsafeAddr dest)
 
 proc newTextCache: TextCache =
   new result
 
 proc renderText(renderer: RendererPtr, font: FontPtr, text: string,
                 x, y, outline: cint, color: Color): CacheLine =
-  font.setFontOutline(outline)
-  let surface = font.renderUtf8Blended(text.cstring, color)
-  sdlFailIf surface.isNil: "Could not render text surface"
+  font.safeSetFontOutline(outline)
+  let surface = font.safeRenderUtf8Blended(text.cstring, color)
 
-  discard surface.setSurfaceAlphaMod(color.a)
+  surface.safeSetSurfaceAlphaMod(color.a)
 
   result.w = surface.w
   result.h = surface.h
-  result.texture = renderer.createTextureFromSurface(surface)
-  sdlFailIf result.texture.isNil: "Could not create texture from rendered text"
+  result.texture = renderer.safeCreateTextureFromSurface(surface)
 
-  surface.freeSurface()
+  surface.safeFreeSurface()
 
 proc renderText(game: Game, text: string, x, y: cint, color: Color,
                 tc: TextCache) =
@@ -123,7 +117,8 @@ proc renderText(game: Game, text: string, x, y: cint, color: Color,
 
   if text != tc.text:
     for i in 0..1:
-      tc.cache[i].texture.destroy()
+      if tc.cache[i].texture != nil:
+        tc.cache[i].texture.safeDestroy()
       tc.cache[i] = game.renderer.renderText(
         game.font, text, x, y, passes[i].outline, passes[i].color)
     tc.text = text
@@ -132,8 +127,8 @@ proc renderText(game: Game, text: string, x, y: cint, color: Color,
     var source = rect(0, 0, tc.cache[i].w, tc.cache[i].h)
     var dest = rect(x - passes[i].outline, y - passes[i].outline,
                     tc.cache[i].w, tc.cache[i].h)
-    game.renderer.copyEx(tc.cache[i].texture, source, dest,
-                         angle = 0.0, center = nil)
+    game.renderer.safeCopyEx(tc.cache[i].texture, source, dest,
+                             angle = 0.0, center = nil)
 
 template renderTextCached(game: Game, text: string, x, y: cint, color: Color) =
   block:
@@ -195,9 +190,7 @@ else:
   let fullDataDir = getAppDir() / dataDir
 
   template readRW(filename: string): ptr RWops =
-    var rw = rwFromFile(cstring(fullDataDir / filename), "r")
-    sdlFailIf rw.isNil: "Cannot create RWops from file"
-    rw
+    safeRwFromFile(cstring(fullDataDir / filename), "r")
 
   template readStream(filename: string): Stream =
     var stream = newFileStream(fullDataDir / filename)
@@ -209,13 +202,12 @@ proc newGame(renderer: RendererPtr): Game =
   new result
   result.renderer = renderer
 
-  result.font = openFontRW(
+  result.font = safeOpenFontRW(
     readRW("DejaVuSans.ttf"), freesrc = 1, 28)
-  sdlFailIf result.font.isNil: "Failed to load font"
 
-  result.player = newPlayer(renderer.loadTexture_RW(
+  result.player = newPlayer(renderer.safeLoadTexture_RW(
     readRW("player.png"), freesrc = 1))
-  result.map = newMap(renderer.loadTexture_RW(
+  result.map = newMap(renderer.safeLoadTexture_RW(
     readRW("grass.png"), freesrc = 1),
     readStream("default.map"))
 
@@ -230,7 +222,7 @@ proc toInput(key: Scancode): Input =
 
 proc handleInput(game: Game) =
   var event = defaultEvent
-  while pollEvent(event):
+  while safePollEvent(event):
     case event.kind
     of QuitEvent:
       game.inputs[Input.quit] = true
@@ -252,7 +244,7 @@ proc formatTimeExact(ticks: int): string =
 
 proc render(game: Game, tick: int) =
   # Draw over all drawings of the last frame with the default color
-  game.renderer.clear()
+  game.renderer.safeClear()
   # Actual drawing here
   game.renderer.renderTee(game.player.texture, game.player.pos - game.camera)
   game.renderer.renderMap(game.map, game.camera)
@@ -269,7 +261,7 @@ proc render(game: Game, tick: int) =
       50, 150, white)
 
   # Show the result on screen
-  game.renderer.present()
+  game.renderer.safePresent()
 
 proc getTile(map: Map, x, y: int): uint8 =
   let
@@ -386,38 +378,32 @@ proc logic(game: Game, tick: int) =
   else: discard
 
 proc main =
-  sdlFailIf(not sdl2.init(INIT_VIDEO or INIT_TIMER or INIT_EVENTS)):
-    "SDL2 initialization failed"
+  safe_sdl2.safeInit(INIT_VIDEO or INIT_TIMER or INIT_EVENTS)
 
   # defer blocks get called at the end of the procedure, even if an
   # exception has been thrown
-  defer: sdl2.quit()
+  defer: safe_sdl2.safeQuit()
 
-  sdlFailIf(not setHint("SDL_RENDER_SCALE_QUALITY", "2")):
-    "Linear texture filtering could not be enabled"
+  safeSetHint("SDL_RENDER_SCALE_QUALITY", "2")
 
   const imgFlags: cint = IMG_INIT_PNG
-  sdlFailIf(image.init(imgFlags) != imgFlags):
-    "SDL2 Image initialization failed"
-  defer: image.quit()
+  safeImageInit(imgFlags)
+  defer: safeImageQuit()
 
-  sdlFailIf(ttfInit() == SdlError):
-    "SDL2 TTF initialization failed"
-  defer: ttfQuit()
+  safeTtfInit()
+  defer: safeTtfQuit()
 
-  let window = createWindow(title = "Our own 2D platformer",
+  let window = safeCreateWindow(title = "Our own 2D platformer",
     x = SDL_WINDOWPOS_CENTERED, y = SDL_WINDOWPOS_CENTERED,
     w = windowSize.x, h = windowSize.y, flags = SDL_WINDOW_SHOWN)
-  sdlFailIf window.isNil: "Window could not be created"
-  defer: window.destroy()
+  defer: window.safeDestroy()
 
-  let renderer = window.createRenderer(index = -1,
+  let renderer = window.safeCreateRenderer(index = -1,
     flags = Renderer_Accelerated or Renderer_PresentVsync)
-  sdlFailIf renderer.isNil: "Renderer could not be created"
-  defer: renderer.destroy()
+  defer: renderer.safeDestroy()
 
   # Set the default color to use for drawing
-  renderer.setDrawColor(r = 110, g = 132, b = 174)
+  renderer.safeSetDrawColor(r = 110, g = 132, b = 174)
 
   var
     game = newGame(renderer)

--- a/platformer.nim
+++ b/platformer.nim
@@ -100,7 +100,7 @@ proc newTextCache: TextCache =
 proc renderText(renderer: RendererPtr, font: FontPtr, text: string,
                 x, y, outline: cint, color: Color): CacheLine =
   font.safeSetFontOutline(outline)
-  let surface = font.safeRenderUtf8Blended(text.cstring, color)
+  var surface = font.safeRenderUtf8Blended(text.cstring, color)
 
   surface.safeSetSurfaceAlphaMod(color.a)
 

--- a/platformer.nim
+++ b/platformer.nim
@@ -181,7 +181,7 @@ const dataDir = "data"
 when defined(embedData):
   template readRW(filename: string): ptr RWops =
     const file = staticRead(dataDir / filename)
-    rwFromConstMem(file.cstring, file.len)
+    safeRwFromConstMem(file.cstring, file.len)
 
   template readStream(filename: string): Stream =
     const file = staticRead(dataDir / filename)

--- a/platformer.nim
+++ b/platformer.nim
@@ -393,12 +393,12 @@ proc main =
   safeTtfInit()
   defer: safeTtfQuit()
 
-  let window = safeCreateWindow(title = "Our own 2D platformer",
+  var window = safeCreateWindow(title = "Our own 2D platformer",
     x = SDL_WINDOWPOS_CENTERED, y = SDL_WINDOWPOS_CENTERED,
     w = windowSize.x, h = windowSize.y, flags = SDL_WINDOW_SHOWN)
   defer: window.safeDestroy()
 
-  let renderer = window.safeCreateRenderer(index = -1,
+  var renderer = window.safeCreateRenderer(index = -1,
     flags = Renderer_Accelerated or Renderer_PresentVsync)
   defer: renderer.safeDestroy()
 

--- a/safe_sdl2.nim
+++ b/safe_sdl2.nim
@@ -105,6 +105,8 @@ proc safeSetHint*(name: cstring not nil, value: cstring not nil) {.inline.} =
 
 proc safeCreateRenderer*(window: WindowPtr not nil; index: cint; flags: cint): RendererPtr not nil {.inline.} =
   doAssert sdlInitialized
+  doAssert index >= -1
+  doAssert flags >= 0
   let ret = createRenderer(window, index, flags)
   if ret.isNil:
     sdlFail "Renderer could not be created"

--- a/safe_sdl2.nim
+++ b/safe_sdl2.nim
@@ -70,15 +70,17 @@ proc safeUpdateSurface*(window: WindowPtr) {.inline.} =
   sdlFailIf(not updateSurface(window)):
     "Unable to update window surface"
 
-proc safeDestroy*(surface: SurfacePtr) {.inline.} =
+proc safeDestroy*(surface: var SurfacePtr) {.inline.} =
   doAssert sdlInitialized
   doAssert surface != nil
   destroy(surface)
+  surface = nil
 
-proc safeDestroy*(window: WindowPtr) {.inline.} =
+proc safeDestroy*(window: var WindowPtr) {.inline.} =
   doAssert sdlInitialized
   doAssert window != nil
   destroy(window)
+  window = nil
 
 proc safePollEvent*(event: var Event): Bool32 {.inline.} =
   doAssert sdlInitialized
@@ -120,10 +122,11 @@ proc safeCreateRenderer*(window: WindowPtr; index: cint; flags: cint): RendererP
   else:
     return ret
 
-proc safeDestroy*(renderer: RendererPtr) {.inline.} =
+proc safeDestroy*(renderer: var RendererPtr) {.inline.} =
   doAssert sdlInitialized
   doAssert renderer != nil
   destroy(renderer)
+  renderer = nil
 
 proc safeSetDrawColor*(renderer: RendererPtr; r, g, b: uint8, a = 255'u8) {.inline.} =
   doAssert sdlInitialized
@@ -200,10 +203,11 @@ proc safeFreeSurface*(surface: SurfacePtr) {.inline.} =
   doAssert surface != nil
   freeSurface(surface)
 
-proc safeDestroy*(texture: TexturePtr) {.inline.} =
+proc safeDestroy*(texture: var TexturePtr) {.inline.} =
   doAssert sdlInitialized
   doAssert texture != nil
   destroy texture
+  texture = nil
 
 proc safeOpenFont*(file: cstring; ptsize: cint): FontPtr {.inline.} =
   doAssert ttfInitIalized

--- a/safe_sdl2.nim
+++ b/safe_sdl2.nim
@@ -29,7 +29,7 @@ proc safeInit*(flags: cint) {.inline.} =
   sdlInitialized = true
 
 proc safeCreateWindow*(title: cstring not nil; x, y, w, h: cint;
-                   flags: uint32): WindowPtr not nil {.inline.} =
+                       flags: uint32): WindowPtr not nil {.inline.} =
   doAssert sdlInitialized
   let ret = createWindow(title, x, y, w, h, flags)
   if ret.isNil:

--- a/safe_sdl2.nim
+++ b/safe_sdl2.nim
@@ -15,11 +15,11 @@ proc safeGetError*: cstring not nil {.inline.} =
   else:
     return ret
 
-template sdlFail(reason: string) =
+template sdlFail(reason: string not nil) =
   raise SDLException.newException(
     reason & ", SDL error: " & $safeGetError())
 
-template sdlFailIf(cond: typed, reason: string) =
+template sdlFailIf(cond: typed, reason: string not nil) =
   if cond: sdlFail(reason)
 
 proc safeInit*(flags: cint) {.inline.} =
@@ -28,7 +28,7 @@ proc safeInit*(flags: cint) {.inline.} =
     "SDL2 initialization failed"
   sdlInitialized = true
 
-proc safeCreateWindow*(title: cstring; x, y, w, h: cint;
+proc safeCreateWindow*(title: cstring not nil; x, y, w, h: cint;
                    flags: uint32): WindowPtr not nil {.inline.} =
   doAssert sdlInitialized
   doAssert title != nil
@@ -47,7 +47,7 @@ proc safeGetSurface*(window: WindowPtr): SurfacePtr not nil {.inline.} =
   else:
     return ret
 
-proc safeLoadBMP*(file: string): SurfacePtr not nil {.inline.} =
+proc safeLoadBMP*(file: string not nil): SurfacePtr not nil {.inline.} =
   doAssert sdlInitialized
   doAssert file != nil
   let ret = loadBMP(file)
@@ -106,7 +106,7 @@ proc safeDelay*(ms: uint32) {.inline.} =
   doAssert sdlInitialized
   delay(ms)
 
-proc safeSetHint*(name: cstring, value: cstring) {.inline.} =
+proc safeSetHint*(name: cstring not nil, value: cstring not nil) {.inline.} =
   doAssert sdlInitialized
   doAssert name != nil
   doAssert value != nil
@@ -209,13 +209,13 @@ proc safeDestroy*(texture: var TexturePtr) {.inline.} =
   destroy texture
   texture = nil
 
-proc safeOpenFont*(file: cstring; ptsize: cint): FontPtr {.inline.} =
+proc safeOpenFont*(file: cstring not nil; ptsize: cint): FontPtr {.inline.} =
   doAssert ttfInitIalized
   doAssert file != nil
   result = openFont(file, ptsize)
   sdlFailIf result.isNil: "Failed to load font"
 
-proc safeLoadTexture*(renderer: RendererPtr; file: cstring): TexturePtr not nil {.inline.} =
+proc safeLoadTexture*(renderer: RendererPtr; file: cstring not nil): TexturePtr not nil {.inline.} =
   doAssert sdlInitialized
   doAssert renderer != nil
   doAssert file != nil
@@ -269,7 +269,7 @@ proc safeOpenFontRW*(src: ptr RWops; freesrc: cint; ptsize: cint): FontPtr not n
   else:
     return ret
 
-proc safeRwFromConstMem*(mem: pointer; size: cint): RWopsPtr not nil {.inline.} =
+proc safeRwFromConstMem*(mem: pointer not nil; size: cint): RWopsPtr not nil {.inline.} =
   doAssert sdlInitIalized
   doAssert mem != nil
   doAssert size >= 1

--- a/safe_sdl2.nim
+++ b/safe_sdl2.nim
@@ -199,6 +199,3 @@ proc safeLoadTexture_RW*(renderer: RendererPtr; src: RWopsPtr;
   doAssert src != nil
   result = loadTexture_RW(renderer, src, freesrc)
   sdlFailIf result.isNil: "Unable to load a texture"
-
-  # proc loadTexture_RW*(renderer: RendererPtr; src: RWopsPtr;
-  # freesrc: cint): TexturePtr {.importc: "IMG_LoadTexture_RW".}

--- a/safe_sdl2.nim
+++ b/safe_sdl2.nim
@@ -35,7 +35,7 @@ proc safeCreateWindow*(title: cstring not nil; x, y, w, h: cint;
   if ret.isNil:
     sdlFail "Window could not be created"
   else:
-    return ret    
+    return ret
 
 proc safeGetSurface*(window: WindowPtr): SurfacePtr not nil {.inline.} =
   doAssert sdlInitialized

--- a/safe_sdl2.nim
+++ b/safe_sdl2.nim
@@ -37,9 +37,8 @@ proc safeCreateWindow*(title: cstring not nil; x, y, w, h: cint;
   else:
     return ret
 
-proc safeGetSurface*(window: WindowPtr): SurfacePtr not nil {.inline.} =
+proc safeGetSurface*(window: WindowPtr not nil): SurfacePtr not nil {.inline.} =
   doAssert sdlInitialized
-  doAssert window != nil
   let ret = getSurface(window)
   if ret.isNil:
     sdlFail "Unable to get window surface"
@@ -54,17 +53,14 @@ proc safeLoadBMP*(file: string not nil): SurfacePtr not nil {.inline.} =
   else:
     return ret
 
-proc safeBlitSurface*(src: SurfacePtr; srcrect: ptr Rect; dst: SurfacePtr;
-    dstrect: ptr Rect) {.inline.} =
+proc safeBlitSurface*(src: SurfacePtr not nil; srcrect: ptr Rect; dst: SurfacePtr not nil;
+    dstrect: ptr Rect not nil) {.inline.} =
   doAssert sdlInitialized
-  doAssert src != nil
-  doAssert dst != nil
   sdlFailIf(not blitSurface(src, nil, dst, nil)):
     "Unable to blit an image to a surface"
 
-proc safeUpdateSurface*(window: WindowPtr) {.inline.} =
+proc safeUpdateSurface*(window: WindowPtr not nil) {.inline.} =
   doAssert sdlInitialized
-  doAssert window != nil
   sdlFailIf(not updateSurface(window)):
     "Unable to update window surface"
 
@@ -89,14 +85,12 @@ proc safeQuit*() {.inline.} =
   sdl2.quit()
   sdlInitialized = false
 
-proc safeMapRGB* (format: ptr PixelFormat; r,g,b: uint8): uint32 {.inline.} =
+proc safeMapRGB* (format: ptr PixelFormat not nil; r,g,b: uint8): uint32 {.inline.} =
   doAssert sdlInitialized
-  doAssert format != nil
   mapRGB(format, r, g, b)
 
-proc safeFillRect*(dst: SurfacePtr; rect: ptr Rect; color: uint32) {.inline.} =
+proc safeFillRect*(dst: SurfacePtr not nil; rect: ptr Rect not nil; color: uint32) {.inline.} =
   doAssert sdlInitialized
-  doAssert dst != nil
   sdlFailIf(not fillRect(dst, rect, color)):
     "Unable to fill a rectangular area of a surface"
 
@@ -109,9 +103,8 @@ proc safeSetHint*(name: cstring not nil, value: cstring not nil) {.inline.} =
   sdlFailIf(not setHint(name, value)):
     "Unable to set some hinting-related SDL2 options"
 
-proc safeCreateRenderer*(window: WindowPtr; index: cint; flags: cint): RendererPtr not nil {.inline.} =
+proc safeCreateRenderer*(window: WindowPtr not nil; index: cint; flags: cint): RendererPtr not nil {.inline.} =
   doAssert sdlInitialized
-  doAssert window != nil
   let ret = createRenderer(window, index, flags)
   if ret.isNil:
     sdlFail "Renderer could not be created"
@@ -124,9 +117,8 @@ proc safeDestroy*(renderer: var RendererPtr) {.inline.} =
   destroy(renderer)
   renderer = nil
 
-proc safeSetDrawColor*(renderer: RendererPtr; r, g, b: uint8, a = 255'u8) {.inline.} =
+proc safeSetDrawColor*(renderer: RendererPtr not nil; r, g, b: uint8, a = 255'u8) {.inline.} =
   doAssert sdlInitialized
-  doAssert renderer != nil
   sdlFailIf(not setDrawColor(renderer, r, g, b, a)):
     "Unable to set drawing color"
 
@@ -152,7 +144,7 @@ proc safeCopyEx*(renderer: RendererPtr; texture: TexturePtr;
     "Unable to copy texture data over to a renderer"
 
 proc safeCopy*(renderer: RendererPtr; texture: TexturePtr;
-                         srcrect, dstrect: ptr Rect) {.inline.} =
+                         srcrect, dstrect: ptr Rect not nil) {.inline.} =
   doAssert sdlInitialized
   doAssert renderer != nil
   doAssert texture != nil
@@ -178,26 +170,25 @@ proc safeRenderUtf8Blended*(font: FontPtr; text: cstring; fg: Color): SurfacePtr
   else:
     return ret
 
-proc safeSetSurfaceAlphaMod*(surface: SurfacePtr; alpha: uint8) {.inline.} =
+proc safeSetSurfaceAlphaMod*(surface: SurfacePtr not nil; alpha: uint8) {.inline.} =
   doAssert sdlInitialized
-  doAssert surface != nil
   sdlFailIf(setSurfaceAlphaMod(surface, alpha) != 0):
     "Unable to set surface alpha"
 
-proc safeCreateTextureFromSurface*(renderer: RendererPtr; surface: SurfacePtr): TexturePtr not nil {.inline.} =
+proc safeCreateTextureFromSurface*(renderer: RendererPtr; surface: SurfacePtr not nil): TexturePtr not nil {.inline.} =
   doAssert sdlInitialized
   doAssert renderer != nil
-  doAssert surface != nil
   let ret = createTextureFromSurface(renderer, surface)
   if ret.isNil:
     sdlFail "Unable to render create texture from surface"
   else:
     return ret
 
-proc safeFreeSurface*(surface: SurfacePtr) {.inline.} =
+proc safeFreeSurface*(surface: var SurfacePtr) {.inline.} =
   doAssert sdlInitialized
   doAssert surface != nil
   freeSurface(surface)
+  surface = nil
 
 proc safeDestroy*(texture: var TexturePtr) {.inline.} =
   doAssert sdlInitialized
@@ -210,9 +201,8 @@ proc safeOpenFont*(file: cstring not nil; ptsize: cint): FontPtr {.inline.} =
   result = openFont(file, ptsize)
   sdlFailIf result.isNil: "Failed to load font"
 
-proc safeLoadTexture*(renderer: RendererPtr; file: cstring not nil): TexturePtr not nil {.inline.} =
+proc safeLoadTexture*(renderer: RendererPtr not nil; file: cstring not nil): TexturePtr not nil {.inline.} =
   doAssert sdlInitialized
-  doAssert renderer != nil
   let ret = loadTexture(renderer, file)
   if ret.isNil:
     sdlFail "Failed to load texture"
@@ -252,9 +242,8 @@ proc safeRwFromFile*(file: cstring; mode: cstring not nil): RWopsPtr not nil {.i
   else:
     return ret
 
-proc safeOpenFontRW*(src: ptr RWops; freesrc: cint; ptsize: cint): FontPtr not nil {.inline.} =
+proc safeOpenFontRW*(src: ptr RWops not nil; freesrc: cint; ptsize: cint): FontPtr not nil {.inline.} =
   doAssert ttfInitIalized
-  doAssert src != nil
   doAssert ptsize >= 1
   let ret = openFontRW(src, freesrc, ptsize)
   if ret.isNil:
@@ -271,11 +260,10 @@ proc safeRwFromConstMem*(mem: pointer not nil; size: cint): RWopsPtr not nil {.i
   else:
     return ret
 
-proc safeLoadTexture_RW*(renderer: RendererPtr; src: RWopsPtr;
+proc safeLoadTexture_RW*(renderer: RendererPtr; src: RWopsPtr not nil;
                          freesrc: cint): TexturePtr not nil {.inline.} =
   doAssert sdlInitIalized
   doAssert renderer != nil
-  doAssert src != nil
   let ret = loadTexture_RW(renderer, src, freesrc)
   if ret.isNil:
     sdlFail "Unable to load a texture"

--- a/safe_sdl2.nim
+++ b/safe_sdl2.nim
@@ -31,7 +31,6 @@ proc safeInit*(flags: cint) {.inline.} =
 proc safeCreateWindow*(title: cstring not nil; x, y, w, h: cint;
                    flags: uint32): WindowPtr not nil {.inline.} =
   doAssert sdlInitialized
-  doAssert title != nil
   let ret = createWindow(title, x, y, w, h, flags)
   if ret.isNil:
     sdlFail "Window could not be created"
@@ -49,7 +48,6 @@ proc safeGetSurface*(window: WindowPtr): SurfacePtr not nil {.inline.} =
 
 proc safeLoadBMP*(file: string not nil): SurfacePtr not nil {.inline.} =
   doAssert sdlInitialized
-  doAssert file != nil
   let ret = loadBMP(file)
   if ret.isNil:
     sdlFail "Unable to load BMP image " & file
@@ -108,8 +106,6 @@ proc safeDelay*(ms: uint32) {.inline.} =
 
 proc safeSetHint*(name: cstring not nil, value: cstring not nil) {.inline.} =
   doAssert sdlInitialized
-  doAssert name != nil
-  doAssert value != nil
   sdlFailIf(not setHint(name, value)):
     "Unable to set some hinting-related SDL2 options"
 
@@ -211,14 +207,12 @@ proc safeDestroy*(texture: var TexturePtr) {.inline.} =
 
 proc safeOpenFont*(file: cstring not nil; ptsize: cint): FontPtr {.inline.} =
   doAssert ttfInitIalized
-  doAssert file != nil
   result = openFont(file, ptsize)
   sdlFailIf result.isNil: "Failed to load font"
 
 proc safeLoadTexture*(renderer: RendererPtr; file: cstring not nil): TexturePtr not nil {.inline.} =
   doAssert sdlInitialized
   doAssert renderer != nil
-  doAssert file != nil
   let ret = loadTexture(renderer, file)
   if ret.isNil:
     sdlFail "Failed to load texture"
@@ -249,10 +243,9 @@ proc safeTtfQuit* {.inline.} =
   ttfQuit()
   ttfInitialized = false
 
-proc safeRwFromFile*(file: cstring; mode: cstring): RWopsPtr not nil {.inline.} =
+proc safeRwFromFile*(file: cstring; mode: cstring not nil): RWopsPtr not nil {.inline.} =
   doAssert sdlInitialized
-  doAssert file != nil
-  doAssert mode != nil
+  doassert file != nil
   let ret = rwFromFile(file, mode)
   if ret.isNil:
     sdlFail "Cannot create RWops from file"
@@ -271,7 +264,6 @@ proc safeOpenFontRW*(src: ptr RWops; freesrc: cint; ptsize: cint): FontPtr not n
 
 proc safeRwFromConstMem*(mem: pointer not nil; size: cint): RWopsPtr not nil {.inline.} =
   doAssert sdlInitIalized
-  doAssert mem != nil
   doAssert size >= 1
   let ret = rwFromConstMem(mem, size)
   if ret.isNil:

--- a/safe_sdl2.nim
+++ b/safe_sdl2.nim
@@ -5,8 +5,8 @@ type
 
 proc safeGetError*: cstring not nil {.inline.} =
   let ret = getError()
-  if ret.isNil:
-    doAssert false
+  if ret.isNil or ret == "":
+    raise SDLException.newException("Unable to get an SDL2 error!")
   else:
     return ret
 

--- a/safe_sdl2.nim
+++ b/safe_sdl2.nim
@@ -1,0 +1,204 @@
+import sdl2, sdl2.ttf, sdl2.image
+
+type
+  SDLException = object of Exception
+
+proc safeGetError*: cstring {.inline.} =
+  result = getError()
+  doAssert result != nil
+
+template sdlFailIf(cond: typed, reason: string) =
+  if cond: raise SDLException.newException(
+    reason & ", SDL error: " & $safeGetError())
+
+proc safeInit*(flags: cint) {.inline.} =
+  sdlFailIf(not sdl2.init(flags)):
+    "SDL2 initialization failed"
+
+proc safeCreateWindow*(title: cstring; x, y, w, h: cint;
+                   flags: uint32): WindowPtr {.inline.} =
+  doAssert title != nil
+  result = createWindow(title, x, y, w, h, flags)
+  sdlFailIf result.isNil:
+    "Window could not be created"
+
+proc safeGetSurface*(window: WindowPtr): SurfacePtr {.inline.} =
+  doAssert window != nil
+  result = getSurface(window)
+  sdlFailIf result.isNil:
+    "Unable to get window surface"
+
+proc safeLoadBMP*(file: string): SurfacePtr {.inline.} =
+  doAssert file != nil
+  result = loadBMP(file)
+  sdlFailIf result.isNil:
+    "Unable to load BMP image " & file
+
+proc safeBlitSurface*(src: SurfacePtr; srcrect: ptr Rect; dst: SurfacePtr;
+    dstrect: ptr Rect) {.inline.} =
+  doAssert src != nil
+  doAssert dst != nil
+  sdlFailIf(not blitSurface(src, nil, dst, nil)):
+    "Unable to blit an image to a surface"
+
+proc safeUpdateSurface*(window: WindowPtr) {.inline.} =
+  doAssert window != nil
+  sdlFailIf(not updateSurface(window)):
+    "Unable to update window surface"
+
+proc safeDestroy*(surface: SurfacePtr) {.inline.} =
+  doAssert surface != nil
+  destroy(surface)
+
+proc safeDestroy*(window: WindowPtr) {.inline.} =
+  doAssert window != nil
+  destroy(window)
+
+proc safePollEvent*(event: var Event): Bool32 {.inline.} =
+  return pollEvent(event)
+
+proc safeQuit*() {.inline.} =
+  sdl2.quit()
+
+proc safeMapRGB* (format: ptr PixelFormat; r,g,b: uint8): uint32 {.inline.} =
+  doAssert format != nil
+  mapRGB(format, r, g, b)
+
+proc safeFillRect*(dst: SurfacePtr; rect: ptr Rect; color: uint32) {.inline.} =
+  doAssert dst != nil
+  sdlFailIf(not fillRect(dst, rect, color)):
+    "Unable to fill a rectangular area of a surface"
+
+proc safeDelay*(ms: uint32) {.inline.} =
+  delay(ms)
+
+proc safeSetHint*(name: cstring, value: cstring) {.inline.} =
+  doAssert name != nil
+  doAssert value != nil
+  sdlFailIf(not setHint(name, value)):
+    "Unable to set some hinting-related SDL2 options"
+
+proc safeCreateRenderer*(window: WindowPtr; index: cint; flags: cint): RendererPtr {.inline.} =
+  doAssert window != nil
+  result = createRenderer(window, index, flags)
+  sdlFailIf result.isNil: "Renderer could not be created"
+
+proc safeDestroy*(renderer: RendererPtr) {.inline.} =
+  doAssert renderer != nil
+  destroy(renderer)
+
+proc safeSetDrawColor*(renderer: RendererPtr; r, g, b: uint8, a = 255'u8) {.inline.} =
+  doAssert renderer != nil
+  sdlFailIf(not setDrawColor(renderer, r, g, b, a)):
+    "Unable to set drawing color"
+
+proc safeClear*(renderer: RendererPtr) {.inline.} =
+  doAssert renderer != nil
+  sdlFailIf(clear(renderer) != 0):
+    "Unable to clear renderer"
+
+proc safePresent*(renderer: RendererPtr) {.inline.} =
+  doAssert renderer != nil
+  present(renderer)
+
+proc safeCopyEx*(renderer: RendererPtr; texture: TexturePtr;
+                 srcrect, dstrect: var Rect; angle: cdouble; center: ptr Point;
+                 flip: RendererFlip = SDL_FLIP_NONE) {.inline.} =
+  doAssert renderer != nil
+  doAssert texture != nil
+
+  sdlFailIf(not copyEx(renderer, texture, srcrect, dstrect, angle, center, flip)):
+    "Unable to copy texture data over to a renderer"
+
+proc safeCopy*(renderer: RendererPtr; texture: TexturePtr;
+                         srcrect, dstrect: ptr Rect) {.inline.} =
+
+  doAssert renderer != nil
+  doAssert texture != nil
+  doAssert srcrect != nil
+  doAssert dstrect != nil
+
+  sdlFailIf(not sdl2.copy(renderer, texture, srcrect, dstrect)):
+    "Unable to copy texture data over to a renderer"
+
+proc safeSetFontOutline*(font: FontPtr, outline: cint) {.inline.} =
+  doAssert font != nil
+  doAssert outline >= 0
+  setFontOutline(font, outline)
+
+proc safeRenderUtf8Blended*(font: FontPtr; text: cstring; fg: Color): SurfacePtr {.inline.} =
+  doAssert font != nil
+  doAssert text != nil
+  result = renderUtf8Blended(font, text, fg)
+  sdlFailIf result.isNil: "Unable to render UTF8-blended text"
+
+proc safeSetSurfaceAlphaMod*(surface: SurfacePtr; alpha: uint8) {.inline.} =
+  doAssert surface != nil
+  sdlFailIf(setSurfaceAlphaMod(surface, alpha) != 0):
+    "Unable to set surface alpha"
+
+proc safeCreateTextureFromSurface*(renderer: RendererPtr; surface: SurfacePtr): TexturePtr {.inline.} =
+  doAssert renderer != nil
+  doAssert surface != nil
+  result = createTextureFromSurface(renderer, surface)
+  sdlFailIf result.isNil: "Unable to render create texture from surface"
+
+proc safeFreeSurface*(surface: SurfacePtr) {.inline.} =
+  doAssert surface != nil
+  freeSurface(surface)
+
+proc safeDestroy*(texture: TexturePtr) {.inline.} =
+  doAssert texture != nil
+  destroy texture
+
+proc safeOpenFont*(file: cstring; ptsize: cint): FontPtr {.inline.} =
+  doAssert file != nil
+  result = openFont(file, ptsize)
+  sdlFailIf result.isNil: "Failed to load font"
+
+proc safeLoadTexture*(renderer: RendererPtr; file: cstring): TexturePtr {.inline.} =
+  doAssert renderer != nil
+  doAssert file != nil
+  result = loadTexture(renderer, file)
+  sdlFailIf result.isNil: "Failed to load texture"
+
+proc safeImageInit*(flags: cint = IMG_INIT_JPG or IMG_INIT_PNG) {.inline.} =
+  sdlFailIf(image.init(flags) != flags):
+    "SDL2 Image initialization failed"
+
+proc safeImageQuit* {.inline.} =
+  image.quit()
+
+proc safeTtfInit* {.inline.} =
+  sdlFailIf(ttfInit() == SdlError): "SDL2 TTF initialization failed"
+
+proc safeTtfQuit* {.inline.} =
+  ttfQuit()
+
+proc safeRwFromFile*(file: cstring; mode: cstring): RWopsPtr {.inline.} =
+  doAssert file != nil
+  doAssert mode != nil
+  result = rwFromFile(file, mode)
+  sdlFailIf result.isNil: "Cannot create RWops from file"
+
+proc safeOpenFontRW*(src: ptr RWops; freesrc: cint; ptsize: cint): FontPtr {.inline.} =
+  doAssert src != nil
+  doAssert ptsize >= 1
+  result = openFontRW(src, freesrc, ptsize)
+  sdlFailIf result.isNil: "Unable to read font from file"
+
+proc safeRwFromConstMem*(mem: pointer; size: cint): RWopsPtr {.inline.} =
+  doAssert mem != nil
+  doAssert size >= 1
+  result = rwFromConstMem(mem, size)
+  sdlFailIf result.isNil: "Unable to read from const memory"
+
+proc safeLoadTexture_RW*(renderer: RendererPtr; src: RWopsPtr;
+                         freesrc: cint): TexturePtr {.inline.} =
+  doAssert renderer != nil
+  doAssert src != nil
+  result = loadTexture_RW(renderer, src, freesrc)
+  sdlFailIf result.isNil: "Unable to load a texture"
+
+  # proc loadTexture_RW*(renderer: RendererPtr; src: RWopsPtr;
+  # freesrc: cint): TexturePtr {.importc: "IMG_LoadTexture_RW".}


### PR DESCRIPTION
Now using some hopefully relatively-safe SDL2 function wrappers.

platformer.nim no longer needs to do error checking for SDL2 calls, so there's a bit less boilerplate.

Also, fixed a Nim compiler warning (Nim 0.17.2):

```
platformer.nim(376, 18) Warning: expr is deprecated [Deprecated]
```